### PR TITLE
Using relative paths in make:auth generated blade

### DIFF
--- a/src/Illuminate/Auth/Console/stubs/make/views/layouts/app.stub
+++ b/src/Illuminate/Auth/Console/stubs/make/views/layouts/app.stub
@@ -11,7 +11,7 @@
     <title>{{ config('app.name', 'Laravel') }}</title>
 
     <!-- Styles -->
-    <link href="/css/app.css" rel="stylesheet">
+    <link href="./css/app.css" rel="stylesheet">
 
     <!-- Scripts -->
     <script>
@@ -82,6 +82,6 @@
     </div>
 
     <!-- Scripts -->
-    <script src="/js/app.js"></script>
+    <script src="./js/app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Changed the paths to css and js files in the by make:auth generated app.layout.blade.php via changing it accordingly in framework/src/Illuminate/Auth/Console/stubs/make/views/layouts/app.stub to relative file paths in order to allow for different web server setups then web server root == public/
